### PR TITLE
Add ExecutionEngineId to skvbc SimpleRequest

### DIFF
--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -141,9 +141,9 @@ bool InternalCommandsHandler::executeWriteCommand(uint32_t requestSize,
   auto *writeReq = (SimpleCondWriteRequest *)request;
   LOG_INFO(m_logger,
            "Execute WRITE command:"
-               << " type=" << writeReq->header.type << " seqNum=" << sequenceNum
-               << " numOfWrites=" << writeReq->numOfWrites << " numOfKeysInReadSet=" << writeReq->numOfKeysInReadSet
-               << " readVersion=" << writeReq->readVersion
+               << ", executionEngineId=" << (int)writeReq->header.executionEngineId << " type=" << writeReq->header.type
+               << " seqNum=" << sequenceNum << " numOfWrites=" << writeReq->numOfWrites
+               << " numOfKeysInReadSet=" << writeReq->numOfKeysInReadSet << " readVersion=" << writeReq->readVersion
                << " READ_ONLY_FLAG=" << ((flags & MsgFlag::READ_ONLY_FLAG) != 0 ? "true" : "false")
                << " PRE_PROCESS_FLAG=" << ((flags & MsgFlag::PRE_PROCESS_FLAG) != 0 ? "true" : "false")
                << " HAS_PRE_PROCESSED_FLAG=" << ((flags & MsgFlag::HAS_PRE_PROCESSED_FLAG) != 0 ? "true" : "false"));
@@ -264,7 +264,8 @@ bool InternalCommandsHandler::executeReadCommand(
   auto *readReq = (SimpleReadRequest *)request;
   LOG_INFO(m_logger,
            "Execute READ command: type=" << readReq->header.type << ", numberOfKeysToRead="
-                                         << readReq->numberOfKeysToRead << ", readVersion=" << readReq->readVersion);
+                                         << readReq->numberOfKeysToRead << ", readVersion=" << readReq->readVersion
+                                         << ", executionEngineId=" << (int)readReq->header.executionEngineId);
 
   auto minRequestSize = std::max(sizeof(SimpleReadRequest), readReq->getSize());
   if (requestSize < minRequestSize) {

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -199,7 +199,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
                                                     logPropsFile});
 
   } catch (const std::exception& e) {
-    LOG_FATAL(GL, "failed to parse command line arguments: " << e.what());
+    LOG_FATAL(GL, "Failed to Setup Replica: " << e.what());
     throw;
   }
 }

--- a/tests/simpleKVBC/scripts/radio-tests.sh
+++ b/tests/simpleKVBC/scripts/radio-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+cleanup() {
+    killall -q skvbc_replica || true
+    rm -rf simpleKVBTests_DB_*
+    rm -rf radio_config_*
+}
+
+cleanup
+
+../../../tools/GenerateConcordKeys -f 1 -n 4 -r 0 -o radio_config_
+
+../TesterReplica/skvbc_replica -k radio_config_ -i 0 -p &
+../TesterReplica/skvbc_replica -k radio_config_ -i 1 -p &
+../TesterReplica/skvbc_replica -k radio_config_ -i 2 -p &
+../TesterReplica/skvbc_replica -k radio_config_ -i 3 -p &
+
+echo "Sleeping for 5 seconds"
+sleep 5
+time ../TesterClient/skvbc_client -f 1 -c 0 -p 400 -i 4
+
+echo "Finished!"
+cleanup

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.cpp
@@ -56,6 +56,7 @@ TestsBuilder::~TestsBuilder() {
 BlockId TestsBuilder::getInitialLastBlockId() {
   auto *request = SimpleGetLastBlockRequest::alloc();
   request->header.type = GET_LAST_BLOCK;
+  request->header.executionEngineId = 0;
 
   size_t expectedReplySize = sizeof(SimpleReply_GetLastBlock);
   std::vector<char> reply(expectedReplySize);
@@ -86,6 +87,7 @@ void TestsBuilder::retrieveExistingBlocksFromKVB() {
   // KVB is not empty. Read existing blocks and save in the memory.
   auto *request = SimpleReadRequest::alloc(NUMBER_OF_KEYS);
   request->header.type = READ;
+  request->header.executionEngineId = 0;
   request->readVersion = prevLastBlockId_;
   request->numberOfKeysToRead = NUMBER_OF_KEYS;
   SimpleKey *requestKeys = request->keys;
@@ -206,6 +208,7 @@ void TestsBuilder::createAndInsertRandomConditionalWrite() {
 
   auto *request = SimpleCondWriteRequest::alloc(numOfKeysInReadSet, numOfWrites);
   request->header.type = COND_WRITE;
+  request->header.executionEngineId = 0;
   request->readVersion = readVersion;
   request->numOfKeysInReadSet = numOfKeysInReadSet;
   request->numOfWrites = numOfWrites;
@@ -258,6 +261,7 @@ void TestsBuilder::createAndInsertRandomRead() {
   size_t numberOfKeysToRead = (rand() % (MAX_READS_IN_REQ - 1)) + 1;
   auto *request = SimpleReadRequest::alloc(numberOfKeysToRead);
   request->header.type = READ;
+  request->header.executionEngineId = 0;
   request->readVersion = readVersion;
   request->numberOfKeysToRead = numberOfKeysToRead;
 
@@ -300,6 +304,7 @@ void TestsBuilder::createAndInsertGetLastBlock() {
   // Create request
   auto *request = SimpleGetLastBlockRequest::alloc();
   request->header.type = GET_LAST_BLOCK;
+  request->header.executionEngineId = 0;
 
   // Add request to m_requests
   requests_.push_back((SimpleRequest *)request);

--- a/tests/simpleKVBC/simpleKVBTestsBuilder.hpp
+++ b/tests/simpleKVBC/simpleKVBTestsBuilder.hpp
@@ -66,8 +66,11 @@ enum RequestType : char {
   ADD_REMOVE_NODE = 7
 };
 
+using ExecutionEngineId = uint8_t;
+
 struct SimpleRequest {
   RequestType type = {NONE};
+  ExecutionEngineId executionEngineId = 0;
 };
 
 struct SimpleGetLastBlockRequest {


### PR DESCRIPTION
This allows dispatching requests to different execution engines. Add it
to each generated request and print it for read and write requests
received in the TesterReplica.

Also add a new script for running TesterReplica and TesterClient for our
radio related tests. It generates new keys and concord configuration each
run because the old config used by the basic scripts is no longer valid.
This will keep it working with any changes to configuration.